### PR TITLE
Add support for tokensregex/semgrex/tregex

### DIFF
--- a/corenlp/client.py
+++ b/corenlp/client.py
@@ -201,11 +201,17 @@ class CoreNLPClient(RobustService):
         parseFromDelimitedString(doc, r.content)
         return doc
 
-    def tokensregex(self, text, pattern, filter=False):
-        return self.__regex('/tokensregex', text, pattern, filter)
+    def tokensregex(self, text, pattern, filter=False, to_words=False):
+        matches = self.__regex('/tokensregex', text, pattern, filter)
+        if not to_words:
+            return matches
+        return self.regex_matches_to_indexed_words(matches)
 
-    def semgrex(self, text, pattern, filter=False):
-        return self.__regex('/semgrex', text, pattern, filter)
+    def semgrex(self, text, pattern, filter=False, to_words=False):
+        matches = self.__regex('/semgrex', text, pattern, filter)
+        if not to_words:
+            return matches
+        return self.regex_matches_to_indexed_words(matches)
 
     def tregrex(self, text, pattern, filter=False):
         return self.__regex('/tregex', text, pattern, filter)
@@ -229,5 +235,16 @@ class CoreNLPClient(RobustService):
         except:
             pass
         return output
+
+    @staticmethod
+    def regex_matches_to_indexed_words(matches):
+        """Transforms tokensregex and semgrex matches to indexed words.
+        :param matches: unprocessed regex matches
+        :return: flat array of indexed words
+        """
+        words = [dict(v, **dict([('sentence', i)]))
+                 for i, s in enumerate(matches['sentences'])
+                 for k, v in s.items() if k != 'length']
+        return words
 
 __all__ = ["CoreNLPClient", "AnnotationException", "TimeoutException", "to_text"]

--- a/corenlp/client.py
+++ b/corenlp/client.py
@@ -4,6 +4,7 @@ Python CoreNLP: a server based interface to Java CoreNLP.
 import io
 import os
 import logging
+import json
 import shlex
 import subprocess
 import time
@@ -199,5 +200,34 @@ class CoreNLPClient(RobustService):
         doc = Document()
         parseFromDelimitedString(doc, r.content)
         return doc
+
+    def tokensregex(self, text, pattern, filter=False):
+        return self.__regex('/tokensregex', text, pattern, filter)
+
+    def semgrex(self, text, pattern, filter=False):
+        return self.__regex('/semgrex', text, pattern, filter)
+
+    def tregrex(self, text, pattern, filter=False):
+        return self.__regex('/tregex', text, pattern, filter)
+
+    def __regex(self, path, text, pattern, filter):
+        """Send a regex-related request to the CoreNLP server.
+        :param (str | unicode) path: the path for the regex endpoint
+        :param text: raw text for the CoreNLPServer to apply the regex
+        :param (str | unicode) pattern: regex pattern
+        :param (bool) filter: option to filter sentences that contain matches, if false returns matches
+        :return: request result
+        """
+        r = requests.get(
+            self.endpoint + path, params={
+                'pattern': pattern,
+                'filter': filter,
+            }, data=text)
+        output = r.text
+        try:
+            output = json.loads(r.text)
+        except:
+            pass
+        return output
 
 __all__ = ["CoreNLPClient", "AnnotationException", "TimeoutException", "to_text"]


### PR DESCRIPTION
## Description

This branch adds basic support for tokensregex/semgrex/tregex. Users can perform these regex queries via methods exposed by the `CoreNLPClient` object.

For tokensregex and semgrex, users can enable a `to_words` flag that will convert the output from the default sentence-separated format to a flat list of mentions.

(Note: `to_words` only causes the top-level matches to be flattened. For tokensregex queries that have nested matches, only the topmost-level matches are flattened and the nested matches are untouched.)

## Examples

### `tokensregex` Demo
```python
annotators = 'tokenize ssplit ner depparse'.split()
client = corenlp.CoreNLPClient(annotators=annotators)

# Example pattern from: https://nlp.stanford.edu/software/tokensregex.shtml
text = 'Hello. Bob Ross was a famous painter. Goodbye.'
pattern = '([ner: PERSON]+) /was|is/ /an?/ []{0,3} /painter|artist/'
matches = client.tokensregex(text, pattern)
print(json.dumps(matches, indent=2))
```
Output:
```
{
  "sentences": [
    {
      "length": 0
    },
    {
      "0": {
        "text": "Ross was a famous painter",
        "begin": 1,
        "end": 6,
        "1": {
          "text": "Ross",
          "begin": 1,
          "end": 2
        }
      },
      "length": 1
    },
    {
      "length": 0
    }
  ]
}
```

### `semgrex` Demo
```python
annotators = 'tokenize ssplit depparse'.split()
client = corenlp.CoreNLPClient(annotators=annotators)

text = 'I ran.'
pattern = '{} < {}'
matches = client.semgrex(text, pattern, to_words=True)
print(json.dumps(matches, indent=2))
```
Output:
```
[
  {
    "text": ".",
    "begin": 2,
    "end": 3,
    "sent": 0
  },
  {
    "text": "I",
    "begin": 0,
    "end": 1,
    "sent": 0
  }
]
```

*more on the way*