### PR TITLE
fix example code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Annotation Server Usage
 
 .. code-block:: python
 
-  from corenlp import CoreNLPClient
+  import corenlp
 
   text = "Chris wrote a simple sentence that he parsed with Stanford CoreNLP."
 


### PR DESCRIPTION
Since the code below is:
(Line 30)
```python
with corenlp.CoreNLPClient(annotators="tokenize ssplit".split()) as
client:
```
(Line 38)
```python
assert corenlp.to_text(sentence) == text
```
the module name “corenlp” should be imported at the beginning.